### PR TITLE
deploy: make post-initial deploy improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ dist
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+.vscode
 
 # yarn v2
 .yarn/cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 # Use the official Node.js LTS (Long Term Support) image as the base image
 FROM node:lts
 
+# Set the image name
+LABEL www.useauthor.image-name="author-img"
+
+# Set the container name
+LABEL www.useauthor.container-name="author-container"
+
 # Set the working directory in the container
 WORKDIR /app
 
@@ -13,7 +19,6 @@ RUN npm install
 # Install doppler CLI
 RUN (curl -Ls --tlsv1.2 --proto "=https" --retry 3 https://cli.doppler.com/install.sh || wget -t 3 -qO- https://cli.doppler.com/install.sh) | sh
 
-RUN export DOPPLER_TOKEN="$(doppler configs tokens create --project author --config dev api-dev-token --plain)"
 # Copy the rest of the application source code to the container
 COPY . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    container_name: author-container
+    image: author-img
     # Set environment variables required for your NestJS application to connect to PlanetScale
     environment:
       - DOPPLER_TOKEN=${DOPPLER_TOKEN}

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,8 @@ async function bootstrap() {
   };
   const document = SwaggerModule.createDocument(app, config, docsOptions);
   SwaggerModule.setup('api/docs', app, document);
+  const port = process.env.PORT || 3000;
 
-  await app.listen(3000);
+  await app.listen(port, '0.0.0.0');
 }
 bootstrap();

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
 # Get the Doppler token and assign it to the DOPPLER_TOKEN variable
-DOPPLER_TOKEN="$(doppler configs tokens create --project author --config dev docker-dev-token --plain)"
-
-# Start the Docker services using docker-compose with the obtained token
-DOPPLER_TOKEN="$DOPPLER_TOKEN" docker-compose -f docker-compose.yml up --build
+export DOPPLER_TOKEN="$(doppler configs tokens create --project author --config dev docker-dev-token --plain)"
+echo "done exporting doppler token"


### PR DESCRIPTION
- add a `start.sh` file to help with local dev with Doppler
- fix `Application Error` when accessing the API after deploying to `Railway`
- add image and container annotations to standardize between the `Dockerfile` and `docker-compose.yml`